### PR TITLE
Add packer ansible plugin to required

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 sudo apt-get update && sudo apt-get install packer
 
-# Get Packer vbox plugin
+# Get Packer required plugins automatically
+packer init ubuntu-25-04-vbox-amd64.pkr.hcl
+# Or install them manually
 packer plugins install github.com/hashicorp/virtualbox
+packer plugins install github.com/hashicorp/ansible
 
 # Ansible
 sudo apt install ansible

--- a/ubuntu-25-04-vbox-amd64.pkr.hcl
+++ b/ubuntu-25-04-vbox-amd64.pkr.hcl
@@ -84,6 +84,10 @@ packer {
       version = "~> 1"
       source  = "github.com/hashicorp/virtualbox"
     }
+    ansible = {
+      version = "~> 1"
+      source = "github.com/hashicorp/ansible"
+    }
   }
 }
 


### PR DESCRIPTION
- Updates README to show packer plugin installation
- Makes the ansible plugin required in ubuntu-25-04-vbox-amd64.pkr.hcl