### PR TITLE
Add packer ansible plugin to required and Fix arch variable

### DIFF
--- a/ubuntu-25-04-vbox-arm64.pkr.hcl
+++ b/ubuntu-25-04-vbox-arm64.pkr.hcl
@@ -65,7 +65,7 @@ variable "img_name" {
 
 variable "arch" {
   type    = string
-  default = "amd64"
+  default = "arm64"
 }
 
 variable "output_directory" {


### PR DESCRIPTION
- Sets arch variable name to "arm64" (previously amd64)
- Makes the ansible plugin required in ubuntu-25-04-vbox-arm64.pkr.hcl