### PR TITLE
Update project pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,18 @@ This repository contains the build system used for generating USO VMs for labs a
 
 ### Prerequisites
 
-Install `packer` and `ansible` on your machine.
+Install the following dependencies on your machine:
+- `packer`: https://developer.hashicorp.com/packer/install#linux
+- `ansible`: https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-ubuntu
+
+Packer requires the following plugins to be installed:
 
 ```bash
-# Packer
-curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-sudo apt-get update && sudo apt-get install packer
-
 # Get Packer required plugins automatically
 packer init ubuntu-25-04-vbox-amd64.pkr.hcl
 # Or install them manually
 packer plugins install github.com/hashicorp/virtualbox
 packer plugins install github.com/hashicorp/ansible
-
-# Ansible
-sudo apt install ansible
 ```
 
 ### Technical Details

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the build system used for generating USO VMs for labs a
 
 Install the following dependencies on your machine:
 - `packer`: https://developer.hashicorp.com/packer/install#linux
-- `ansible`: https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-ubuntu
+- `ansible`: https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-specific-operating-systems
 
 Packer requires the following plugins to be installed:
 


### PR DESCRIPTION
Remove installation tutorials from documentation.

To prevent outdated or duplicated information, we are
pointing to the official documentation rather than
maintaining a tutorial ourselves.

Fixes: #3