### PR TITLE
Configure second disk ctf challenge

### DIFF
--- a/scripts/ansible/_ctf_challenges.yml
+++ b/scripts/ansible/_ctf_challenges.yml
@@ -3,7 +3,7 @@
   file:
     path: /usr/share/info/emacs-25
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Configure `file-start-of-the-year`
   file:
@@ -21,24 +21,24 @@
     mode: '0644'
 
 # Second disk
-# - name: Copy second-disk scripts
-#   copy:
-#     src: ctf/second-disk/
-#     dest: /tmp/second-disk/
-#     owner: root
-#     group: root
-#     mode: '0755'
-#     remote_src: no
+- name: Copy second-disk scripts
+  copy:
+    src: ctf/second-disk/
+    dest: /tmp/second-disk/
+    owner: root
+    group: root
+    mode: "0755"
+    remote_src: no
 
-# - name: Run second-disk deploy script
-#   command:
-#     cmd: ./deploy
-#     chdir: /tmp/second-disk
+- name: Run second-disk deploy script
+  command:
+    cmd: ./deploy
+    chdir: /tmp/second-disk
 
-# - name: Clean second-disk scripts
-#   file:
-#     path: /tmp/second-disk
-#     state: absent
+- name: Clean second-disk scripts
+  file:
+    path: /tmp/second-disk
+    state: absent
 
 # MySQL
 - name: Install MySQL server

--- a/scripts/autoinst/ubuntu-25-04-autoinstall.yml
+++ b/scripts/autoinst/ubuntu-25-04-autoinstall.yml
@@ -39,6 +39,8 @@ autoinstall:
     install: true
   updates: all
 
+  # for the detailed storage docs see the Curtin documentation
+  # https://curtin.readthedocs.io/en/latest/topics/storage.html
   storage:
     layout:
       name: direct

--- a/scripts/autoinst/ubuntu-25-04-autoinstall.yml
+++ b/scripts/autoinst/ubuntu-25-04-autoinstall.yml
@@ -42,6 +42,45 @@ autoinstall:
   storage:
     layout:
       name: direct
+    config:
+      - type: disk
+        id: sda
+        match:
+          path: /dev/sda
+        ptable: gpt
+        grub_device: true
+
+      - type: partition
+        id: sda-bios
+        device: sda
+        size: 1M
+        flag: bios_grub
+
+      - type: partition
+        id: sda-root
+        device: sda
+        size: remaining
+
+      - type: format
+        id: sda-fs
+        volume: sda-root
+        fstype: ext4
+
+      - type: mount
+        device: sda-fs
+        path: /
+
+      - type: disk
+        id: sdb
+        match:
+          path: /dev/sdb
+        ptable: gpt
+        grub_device: false
+
+      - type: partition
+        id: sdb-root
+        device: sdb
+        size: remaining
 
   identity:
     hostname: ${hostname}

--- a/ubuntu-25-04-vbox-amd64.pkr.hcl
+++ b/ubuntu-25-04-vbox-amd64.pkr.hcl
@@ -38,6 +38,11 @@ variable "disk_size" {
   default = 40000
 }
 
+variable "ctf_disk_size" {
+  type    = number
+  default = 10
+}
+
 variable "disk_format" {
   type    = string
   default = "ova"
@@ -110,6 +115,7 @@ source "virtualbox-iso" "ubuntu-25-04" {
    }
   shutdown_command     = "rm -rf ~/.ansible && echo '${var.password}' | sudo -S poweroff"
   disk_size            = var.disk_size
+  disk_additional_size = [ var.ctf_disk_size ]
   vm_name              = "${var.img_name}"
   format               = var.disk_format
   cpus                 = var.cpus


### PR DESCRIPTION
- Updates packer vbox config to create a secondary disk
- Updates ubuntu autoinstall to explicitly target the two disks
- Uncomments the second disk ctf ansible setup

Fixes: #9